### PR TITLE
fix: csv read directories

### DIFF
--- a/data/main.py
+++ b/data/main.py
@@ -19,8 +19,8 @@ from collections import defaultdict
 from flask import Flask, render_template
 
 app = Flask(__name__)
-data = pd.read_csv('D:/Backup/Desktop/programs/musicre/data/data.csv')
-genre_data = pd.read_csv('D:/Backup/Desktop/programs/musicre/data/data_by_genres.csv')
+data = pd.read_csv('data.csv')
+genre_data = pd.read_csv('data_by_genres.csv')
 cluster_pipeline = Pipeline([('scaler', StandardScaler()), ('kmeans', KMeans(n_clusters=10))])
 X = genre_data.select_dtypes(np.number)
 cluster_pipeline.fit(X)


### PR DESCRIPTION
data = pd.read_csv('D:/Backup/Desktop/programs/musicre/data/data.csv')
genre_data = pd.read_csv('D:/Backup/Desktop/programs/musicre/data/data_by_genres.csv')

The directories framed like this will lead to an error while hosting the flask implementation.

data = pd.read_csv('data.csv')
genre_data = pd.read_csv('data_by_genres.csv')

This modification should fix it!

(follow me back on github pls i like having github followers)